### PR TITLE
Handle zero length arrays

### DIFF
--- a/bivrost-abi-parser/src/test/kotlin/pm/gnosis/AbiParserTest.kt
+++ b/bivrost-abi-parser/src/test/kotlin/pm/gnosis/AbiParserTest.kt
@@ -122,13 +122,13 @@ class AbiParserTest {
         val type = AbiParser.mapType(testParameter("uint[5][]"), testContext())
         assertType(type, AbiParser.VectorTypeHolder::class)
         val pType = type as AbiParser.VectorTypeHolder
-        assertEquals(SolidityBase.VectorST::class.asClassName(), pType.listType)
+        assertEquals(SolidityBase.Vector::class.asClassName(), pType.listType)
 
         // First generic type
         val g1Type = pType.itemType
         assertType(g1Type, AbiParser.ArrayTypeHolder::class)
         val g1pType = g1Type as AbiParser.ArrayTypeHolder
-        assertEquals(SolidityBase.ArrayST::class.asClassName(), g1pType.listType)
+        assertEquals(SolidityBase.Array::class.asClassName(), g1pType.listType)
 
         // Second generic type
         val g2Type = g1pType.itemType
@@ -140,7 +140,7 @@ class AbiParserTest {
         val type = AbiParser.mapType(testParameter("string[]"), testContext())
         assertType(type, AbiParser.VectorTypeHolder::class)
         val pType = type as AbiParser.VectorTypeHolder
-        assertEquals(SolidityBase.VectorDT::class.asClassName(), pType.listType)
+        assertEquals(SolidityBase.Vector::class.asClassName(), pType.listType)
 
         // First generic type
         val g1Type = pType.itemType
@@ -153,7 +153,7 @@ class AbiParserTest {
         assertType(type, AbiParser.ArrayTypeHolder::class)
         val pType = type as AbiParser.ArrayTypeHolder
         assertEquals(5, pType.capacity)
-        assertEquals(SolidityBase.ArrayDT::class.asClassName(), pType.listType)
+        assertEquals(SolidityBase.Array::class.asClassName(), pType.listType)
 
         // First generic type
         val g1Type = pType.itemType
@@ -194,7 +194,7 @@ class AbiParserTest {
 
         // Decode dynamic uint32 array
         assertEquals(
-                SolidityBase.VectorST.Decoder(Solidity.UInt32.DECODER).decode(testData).items,
+                SolidityBase.Vector.Decoder(Solidity.UInt32.DECODER).decode(testData).items,
                 listOf(Solidity.UInt32(BigInteger("456", 16)), Solidity.UInt32(BigInteger("789", 16))))
 
         // Decode bytes
@@ -212,7 +212,7 @@ class AbiParserTest {
          */
 
         val arg1 = Solidity.UInt256(BigInteger("123", 16))
-        val arg2 = SolidityBase.VectorST(
+        val arg2 = SolidityBase.Vector(
                 listOf(Solidity.UInt32(BigInteger("456", 16)), Solidity.UInt32(BigInteger("789", 16)))
         )
         val arg3 = Solidity.Bytes10("1234567890".toByteArray())
@@ -240,11 +240,11 @@ class AbiParserTest {
         ([0x456, 0x789], "Hello, world!", [0x123])
          */
 
-        val arg1 = SolidityBase.ArrayST(
+        val arg1 = SolidityBase.Array(
                 listOf(Solidity.UInt32(BigInteger("456", 16)), Solidity.UInt32(BigInteger("789", 16))), 2
         )
         val arg2 = Solidity.String("Hello, world!")
-        val arg3 = SolidityBase.VectorST(
+        val arg3 = SolidityBase.Vector(
                 listOf(Solidity.UInt32(BigInteger("123", 16)))
         )
         val data = SolidityBase.encodeFunctionArguments(arg1, arg2, arg3)

--- a/bivrost-abi-parser/src/test/kotlin/pm/gnosis/AbiParserTest.kt
+++ b/bivrost-abi-parser/src/test/kotlin/pm/gnosis/AbiParserTest.kt
@@ -18,7 +18,7 @@ import kotlin.reflect.KClass
 
 class AbiParserTest {
 
-    private fun testContext() = AbiParser.GeneratorContext(AbiRoot(ArrayList(), "Test"))
+    private fun testContext() = AbiParser.GeneratorContext(AbiRoot(ArrayList(), "Test"), AbiParser.ArraysMap("com.example"))
 
     private fun testParameter(type: String, name: String = "test", components: List<ParameterJson>? = null)
             = ParameterJson(name, type, components)
@@ -128,7 +128,7 @@ class AbiParserTest {
         val g1Type = pType.itemType
         assertType(g1Type, AbiParser.ArrayTypeHolder::class)
         val g1pType = g1Type as AbiParser.ArrayTypeHolder
-        assertEquals(SolidityBase.Array::class.asClassName(), g1pType.listType)
+        assertEquals(ClassName("com.example.arrays", "Array5"), g1pType.listType)
 
         // Second generic type
         val g2Type = g1pType.itemType
@@ -153,7 +153,7 @@ class AbiParserTest {
         assertType(type, AbiParser.ArrayTypeHolder::class)
         val pType = type as AbiParser.ArrayTypeHolder
         assertEquals(5, pType.capacity)
-        assertEquals(SolidityBase.Array::class.asClassName(), pType.listType)
+        assertEquals(ClassName("com.example.arrays", "Array5"), pType.listType)
 
         // First generic type
         val g1Type = pType.itemType
@@ -240,7 +240,7 @@ class AbiParserTest {
         ([0x456, 0x789], "Hello, world!", [0x123])
          */
 
-        val arg1 = SolidityBase.Array(
+        val arg1 = TestArray(
                 listOf(Solidity.UInt32(BigInteger("456", 16)), Solidity.UInt32(BigInteger("789", 16))), 2
         )
         val arg2 = Solidity.String("Hello, world!")
@@ -267,5 +267,7 @@ class AbiParserTest {
                 "0000000000000000000000000000000000000000000000000000000000000123"
         assertEquals(data, expected)
     }
+
+    private class TestArray<out T : SolidityBase.Type>(items: List<T>, capacity: Int) : SolidityBase.Array<T>(items, capacity)
 
 }

--- a/bivrost-gradle-plugin/src/main/kotlin/pm/gnosis/plugin/BivrostPlugin.kt
+++ b/bivrost-gradle-plugin/src/main/kotlin/pm/gnosis/plugin/BivrostPlugin.kt
@@ -40,7 +40,6 @@ class BivrostPlugin : Plugin<Project> {
         variants.all { variant ->
             val outputDir = project.buildDir.resolve(
                     "generated/source/abi/${variant.dirName}")
-
             val task = project.tasks.create("pm.gnosis.generate${variant.name.capitalize()}AbiWrapper")
             task.outputs.dir(outputDir)
             variant.registerJavaGeneratingTask(task, outputDir)
@@ -60,11 +59,16 @@ class BivrostPlugin : Plugin<Project> {
                         inputs.files(abiFolder.listFiles())
 
                         doLast {
+                            val packageName = variant.applicationId
+                            // We can reuse arrays for all ABIs
+                            val arraysMap = AbiParser.ArraysMap(packageName)
+
                             abiFolder.listFiles().forEach {
                                 println("Generating wrapper for <$it>")
-                                AbiParser.generateWrapper(variant.applicationId, it.readText(), outputDir)
+                                AbiParser.generateWrapper(packageName, it.readText(), outputDir, arraysMap)
                             }
 
+                            arraysMap.generate(outputDir)
                         }
                     }
                 }

--- a/bivrost-solidity-types/src/main/kotlin/pm/gnosis/model/SolidityBase.kt
+++ b/bivrost-solidity-types/src/main/kotlin/pm/gnosis/model/SolidityBase.kt
@@ -322,7 +322,7 @@ object SolidityBase {
     @Suppress("MemberVisibilityCanPrivate")
     fun partitionData(data: String): List<String> {
         var noPrefix = data.removePrefix("0x")
-        if (noPrefix.isEmpty() || noPrefix.length.rem(PADDED_HEX_LENGTH) != 0) throw IllegalArgumentException("Data is not a multiple of ${PADDED_HEX_LENGTH}")
+        if (noPrefix.length.rem(PADDED_HEX_LENGTH) != 0) throw IllegalArgumentException("Data is not a multiple of $PADDED_HEX_LENGTH")
         val properties = arrayListOf<String>()
 
         while (noPrefix.length >= PADDED_HEX_LENGTH) {

--- a/bivrost-solidity-types/src/test/kotlin/pm/gnosis/model/SolidityBaseTest.kt
+++ b/bivrost-solidity-types/src/test/kotlin/pm/gnosis/model/SolidityBaseTest.kt
@@ -176,48 +176,48 @@ class SolidityBaseTest {
     @Test
     fun testDynamicArrayEncoding() {
         assertEquals("000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000004560000000000000000000000000000000000000000000000000000000000000789",
-                SolidityBase.VectorST(listOf(Solidity.UInt32(BigInteger("456", 16)), Solidity.UInt32(BigInteger("789", 16)))).encode())
+                SolidityBase.Vector(listOf(Solidity.UInt32(BigInteger("456", 16)), Solidity.UInt32(BigInteger("789", 16)))).encode())
 
         assertEquals("000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000",
-                SolidityBase.VectorST(listOf(Solidity.Bool(true), Solidity.Bool(false))).encode())
+                SolidityBase.Vector(listOf(Solidity.Bool(true), Solidity.Bool(false))).encode())
 
         assertEquals("0000000000000000000000000000000000000000000000000000000000000000",
-                SolidityBase.VectorST(emptyList()).encode())
+                SolidityBase.Vector(emptyList()).encode())
     }
 
     @Test
     fun testDynamicArrayDecoding() {
         var testData = "000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000004560000000000000000000000000000000000000000000000000000000000000789"
         assertEquals(listOf(Solidity.UInt256(BigInteger("456", 16)), Solidity.UInt256(BigInteger("789", 16))),
-                SolidityBase.VectorST.Decoder(Solidity.UInt256.DECODER).decode(SolidityBase.PartitionData.of(testData)).items)
+                SolidityBase.Vector.Decoder(Solidity.UInt256.DECODER).decode(SolidityBase.PartitionData.of(testData)).items)
 
         testData = "0000000000000000000000000000000000000000000000000000000000000003000000000000000000000000000000000000000000000000000000000000032100000000000000000000000000000000000000000000000000000000000004560000000000000000000000000000000000000000000000000000000000000789"
         val source = SolidityBase.PartitionData.of(testData)
-        val expected = SolidityBase.VectorST(listOf(
-                SolidityBase.ArrayST(listOf(Solidity.UInt256(BigInteger("321", 16))), 1),
-                SolidityBase.ArrayST(listOf(Solidity.UInt256(BigInteger("456", 16))), 1),
-                SolidityBase.ArrayST(listOf(Solidity.UInt256(BigInteger("789", 16))), 1)
+        val expected = SolidityBase.Vector(listOf(
+                SolidityBase.Array(listOf(Solidity.UInt256(BigInteger("321", 16))), 1),
+                SolidityBase.Array(listOf(Solidity.UInt256(BigInteger("456", 16))), 1),
+                SolidityBase.Array(listOf(Solidity.UInt256(BigInteger("789", 16))), 1)
         ))
-        assertEquals(expected, SolidityBase.VectorST.Decoder(SolidityBase.ArrayST.Decoder(Solidity.UInt256.DECODER, 1)).decode(source))
+        assertEquals(expected, SolidityBase.Vector.Decoder(SolidityBase.Array.Decoder(Solidity.UInt256.DECODER, 1)).decode(source))
     }
 
     @Test
     fun testFixedArrayEncoding() {
         assertEquals("00000000000000000000000000000000000000000000000000000000000004560000000000000000000000000000000000000000000000000000000000000789",
-                SolidityBase.ArrayST(listOf(Solidity.UInt32(BigInteger("456", 16)), Solidity.UInt32(BigInteger("789", 16))), 2).encode())
+                SolidityBase.Array(listOf(Solidity.UInt32(BigInteger("456", 16)), Solidity.UInt32(BigInteger("789", 16))), 2).encode())
 
         assertEquals("00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000",
-                SolidityBase.ArrayST(listOf(Solidity.Bool(true), Solidity.Bool(false)), 2).encode())
+                SolidityBase.Array(listOf(Solidity.Bool(true), Solidity.Bool(false)), 2).encode())
 
         assertEquals("00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-                SolidityBase.ArrayST(listOf(Solidity.Bytes1(kotlin.ByteArray(0)), Solidity.Bytes1(kotlin.ByteArray(0))), 2).encode())
+                SolidityBase.Array(listOf(Solidity.Bytes1(kotlin.ByteArray(0)), Solidity.Bytes1(kotlin.ByteArray(0))), 2).encode())
     }
 
     @Test
     fun testFixedArrayDecoding() {
         val testData = "00000000000000000000000000000000000000000000000000000000000004560000000000000000000000000000000000000000000000000000000000000789"
         assertEquals(listOf(Solidity.UInt256(BigInteger("456", 16)), Solidity.UInt256(BigInteger("789", 16))),
-                SolidityBase.ArrayST.Decoder(Solidity.UInt256.DECODER, 2).decode(SolidityBase.PartitionData.of(testData)).items)
+                SolidityBase.Array.Decoder(Solidity.UInt256.DECODER, 2).decode(SolidityBase.PartitionData.of(testData)).items)
     }
 
     @Test
@@ -225,9 +225,9 @@ class SolidityBaseTest {
         val testData = "00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000321000000000000000000000000000000000000000000000000000000000000076500000000000000000000000000000000000000000000000000000000000004560000000000000000000000000000000000000000000000000000000000000789"
         val source = SolidityBase.PartitionData.of(testData)
         assertEquals(listOf(Solidity.UInt256(BigInteger("321", 16)), Solidity.UInt256(BigInteger("765", 16))),
-                SolidityBase.VectorST.Decoder(Solidity.UInt256.DECODER).decode(source).items)
+                SolidityBase.Vector.Decoder(Solidity.UInt256.DECODER).decode(source).items)
         assertEquals(listOf(Solidity.UInt256(BigInteger("456", 16)), Solidity.UInt256(BigInteger("789", 16))),
-                SolidityBase.ArrayST.Decoder(Solidity.UInt256.DECODER, 2).decode(source).items)
+                SolidityBase.Array.Decoder(Solidity.UInt256.DECODER, 2).decode(source).items)
     }
 
     @Test
@@ -288,9 +288,9 @@ class SolidityBaseTest {
     fun testDecodeEncodeDynamicStringArray() {
         val items = listOf(Solidity.String("Hi"), Solidity.String("I"), Solidity.String("want"),
                 Solidity.String("to"), Solidity.String("learn"), Solidity.String("Solidity"))
-        val encoded = SolidityBase.VectorDT(items).encode()
+        val encoded = SolidityBase.Vector(items).encode()
         assertEquals("Encoded string not correct!", ENCODED_DYNAMIC_STRING_ARRAY, encoded)
-        val decoded = SolidityBase.VectorDT.Decoder(Solidity.String.DECODER).decode(SolidityBase.PartitionData.of(encoded))
+        val decoded = SolidityBase.Vector.Decoder(Solidity.String.DECODER).decode(SolidityBase.PartitionData.of(encoded))
         assertEquals(items.size, decoded.items.size)
         for (i in 0 until items.size) {
             assertEquals(items[i].value, decoded.items[i].value)
@@ -301,9 +301,9 @@ class SolidityBaseTest {
     fun testDecodeEncodeStaticStringArray() {
         val items = listOf(Solidity.String("Hi"), Solidity.String("I"), Solidity.String("want"),
                 Solidity.String("to"), Solidity.String("learn"), Solidity.String("Solidity"))
-        val encoded = SolidityBase.ArrayDT(items, 6).encode()
+        val encoded = SolidityBase.Array(items, 6).encode()
         assertEquals("Encoded string not correct!", ENCODED_STATIC_STRING_ARRAY, encoded)
-        val decoded = SolidityBase.ArrayDT.Decoder(Solidity.String.DECODER, 6).decode(SolidityBase.PartitionData.of(encoded))
+        val decoded = SolidityBase.Array.Decoder(Solidity.String.DECODER, 6).decode(SolidityBase.PartitionData.of(encoded))
         assertEquals(items.size, decoded.items.size)
         for (i in 0 until items.size) {
             assertEquals(items[i].value, decoded.items[i].value)

--- a/bivrost-utils/src/main/kotlin/pm/gnosis/GeneratorUtils.kt
+++ b/bivrost-utils/src/main/kotlin/pm/gnosis/GeneratorUtils.kt
@@ -11,26 +11,27 @@ object GeneratorUtils {
                     .build())
             .build()
 
-    fun generateDecoder(name: String, decodeCode: CodeBlock, isDynamic: Boolean = true, paramName: String = "source"): TypeSpec {
-        val className = ClassName("", name)
+    fun generateDecoder(name: String, decodeCode: CodeBlock, isDynamic: Boolean = true, paramName: String = "source")
+        = generateDecoderBuilder(ClassName("", name), decodeCode, CodeBlock.of("return %L", isDynamic), paramName).build()
+
+    fun generateDecoderBuilder(forClass: TypeName, decodeCode: CodeBlock, isDynamicBlock: CodeBlock, paramName: String = "source"): TypeSpec.Builder {
         return TypeSpec.classBuilder("Decoder")
-                .addSuperinterface(ParameterizedTypeName.get(SolidityBase.TypeDecoder::class.asClassName(), className))
-                .addFun(generateIsDynamicFunction(isDynamic))
-                .addFun(generateDecodeSourceFunction(decodeCode, className, paramName))
-                .build()
+                .addSuperinterface(ParameterizedTypeName.get(SolidityBase.TypeDecoder::class.asClassName(), forClass))
+                .addFun(generateIsDynamicFunction(isDynamicBlock))
+                .addFun(generateDecodeSourceFunction(decodeCode, forClass, paramName))
     }
 
-    fun generateDecodeSourceFunction(decodeCode: CodeBlock, className: ClassName, paramName: String) =
+    fun generateDecodeSourceFunction(decodeCode: CodeBlock, returnType: TypeName, paramName: String) =
             FunSpec.builder("decode")
                     .addParameter(paramName, SolidityBase.PartitionData::class)
                     .addModifiers(KModifier.OVERRIDE)
-                    .returns(className)
+                    .returns(returnType)
                     .addCode(decodeCode)
                     .build()
 
-    fun generateIsDynamicFunction(isDynamic: Boolean): FunSpec = FunSpec.builder("isDynamic")
+    fun generateIsDynamicFunction(isDynamicBlock: CodeBlock): FunSpec = FunSpec.builder("isDynamic")
             .addModifiers(KModifier.OVERRIDE)
             .returns(Boolean::class)
-            .addCode(CodeBlock.of("return %L", isDynamic))
+            .addCode(isDynamicBlock)
             .build()
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,7 +3,7 @@ include ':bivrost-gradle-plugin'
 include ':bivrost-solidity-types'
 include ':bivrost-solidity-types-generator'
 include ':bivrost-utils'
-//include ':sample:app'
+include ':sample:app'
 
 rootProject.name = 'bivrost-kotlin'
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,7 +3,7 @@ include ':bivrost-gradle-plugin'
 include ':bivrost-solidity-types'
 include ':bivrost-solidity-types-generator'
 include ':bivrost-utils'
-include ':sample:app'
+//include ':sample:app'
 
 rootProject.name = 'bivrost-kotlin'
 


### PR DESCRIPTION
The old specs theoretically allow zero length arrays ( e.g. `uint[0]`)
This PR implements that these are handled gracefully.

Also we removed the ArrayST/ArrayDT and VectorST/VectorDT in favor of Array and Vector.
The size of a vector is checked on creation and a immutable copy of the array is used.

To indicate what the expected size of an array is, we generate classes for the used arrays when parsing the abis (e.g. `Array5`). These classes are shared between all abi wrappers and are under the subpackage `arrays`