### PR TITLE
Remove old decoder interface

### DIFF
--- a/bivrost-solidity-types/src/main/kotlin/pm/gnosis/model/SolidityBase.kt
+++ b/bivrost-solidity-types/src/main/kotlin/pm/gnosis/model/SolidityBase.kt
@@ -14,10 +14,6 @@ object SolidityBase {
 
     interface Type {
         fun encode(): String
-
-        interface Decoder<out T : Type> {
-            fun decode(source: String): T
-        }
     }
 
     interface StaticType : Type


### PR DESCRIPTION
Changes proposed in this pull request:
- Remove unused decoder interface

@gnosis/mobile-devs
