### PR TITLE
Update contract name JSON key

### DIFF
--- a/bivrost-abi-parser/src/main/kotlin/pm/gnosis/model/AbiJsonModel.kt
+++ b/bivrost-abi-parser/src/main/kotlin/pm/gnosis/model/AbiJsonModel.kt
@@ -3,7 +3,7 @@ package pm.gnosis.model
 import com.squareup.moshi.Json
 
 class AbiRoot(@Json(name = "abi") val abi: List<AbiElementJson>,
-              @Json(name = "contract_name") val contractName: String)
+              @Json(name = "contractName") val contractName: String)
 
 class AbiElementJson(@Json(name = "constant") val constant: Boolean = false,
                      @Json(name = "inputs") val inputs: List<ParameterJson> = listOf(),

--- a/bivrost-abi-parser/src/test/resources/automatic_tests/0_empty_contract/abis/empty_contract.json
+++ b/bivrost-abi-parser/src/test/resources/automatic_tests/0_empty_contract/abis/empty_contract.json
@@ -1,4 +1,4 @@
 {
-  "contract_name": "EmptyContract",
+  "contractName": "EmptyContract",
   "abi": []
 }

--- a/bivrost-abi-parser/src/test/resources/automatic_tests/10_simple_event/abis/abi10.json
+++ b/bivrost-abi-parser/src/test/resources/automatic_tests/10_simple_event/abis/abi10.json
@@ -1,5 +1,5 @@
 {
-  "contract_name": "Abi10",
+  "contractName": "Abi10",
   "abi": [
     {
       "constant": true,

--- a/bivrost-abi-parser/src/test/resources/automatic_tests/11_event_static_indexed/abis/abi11.json
+++ b/bivrost-abi-parser/src/test/resources/automatic_tests/11_event_static_indexed/abis/abi11.json
@@ -1,5 +1,5 @@
 {
-  "contract_name": "Abi11",
+  "contractName": "Abi11",
   "abi": [
     {
       "anonymous": false,

--- a/bivrost-abi-parser/src/test/resources/automatic_tests/12_event_static_not_indexed/abis/abi12.json
+++ b/bivrost-abi-parser/src/test/resources/automatic_tests/12_event_static_not_indexed/abis/abi12.json
@@ -1,5 +1,5 @@
 {
-  "contract_name": "Abi12",
+  "contractName": "Abi12",
   "abi": [
     {
       "anonymous": false,

--- a/bivrost-abi-parser/src/test/resources/automatic_tests/13_simple_event_dynamic_indexed/abis/abi13.json
+++ b/bivrost-abi-parser/src/test/resources/automatic_tests/13_simple_event_dynamic_indexed/abis/abi13.json
@@ -1,5 +1,5 @@
 {
-  "contract_name": "Abi13",
+  "contractName": "Abi13",
   "abi": [
     {
       "anonymous": false,

--- a/bivrost-abi-parser/src/test/resources/automatic_tests/14_simple_event_dynamic_not_indexed/abis/abi14.json
+++ b/bivrost-abi-parser/src/test/resources/automatic_tests/14_simple_event_dynamic_not_indexed/abis/abi14.json
@@ -1,5 +1,5 @@
 {
-  "contract_name": "Abi14",
+  "contractName": "Abi14",
   "abi": [
     {
       "anonymous": false,

--- a/bivrost-abi-parser/src/test/resources/automatic_tests/15_anonymous_event/abis/abi15.json
+++ b/bivrost-abi-parser/src/test/resources/automatic_tests/15_anonymous_event/abis/abi15.json
@@ -1,5 +1,5 @@
 {
-  "contract_name": "Abi15",
+  "contractName": "Abi15",
   "abi": [
     {
       "anonymous": true,

--- a/bivrost-abi-parser/src/test/resources/automatic_tests/1_simple_function/abis/abi1.json
+++ b/bivrost-abi-parser/src/test/resources/automatic_tests/1_simple_function/abis/abi1.json
@@ -1,5 +1,5 @@
 {
-  "contract_name": "Abi1",
+  "contractName": "Abi1",
   "abi": [
     {
       "constant": true,

--- a/bivrost-abi-parser/src/test/resources/automatic_tests/2_function_no_type/abis/abi2.json
+++ b/bivrost-abi-parser/src/test/resources/automatic_tests/2_function_no_type/abis/abi2.json
@@ -1,5 +1,5 @@
 {
-  "contract_name": "Abi2",
+  "contractName": "Abi2",
   "abi": [
     {
       "constant": true,

--- a/bivrost-abi-parser/src/test/resources/automatic_tests/3_no_inputs_and_outputs/abis/abi3.json
+++ b/bivrost-abi-parser/src/test/resources/automatic_tests/3_no_inputs_and_outputs/abis/abi3.json
@@ -1,5 +1,5 @@
 {
-  "contract_name": "Abi3",
+  "contractName": "Abi3",
   "abi": [
     {
       "constant": true,

--- a/bivrost-abi-parser/src/test/resources/automatic_tests/4_unnamed_function/abis/abi4.json
+++ b/bivrost-abi-parser/src/test/resources/automatic_tests/4_unnamed_function/abis/abi4.json
@@ -1,5 +1,5 @@
 {
-  "contract_name": "Abi4",
+  "contractName": "Abi4",
   "abi": [
     {
       "constant": true,

--- a/bivrost-abi-parser/src/test/resources/automatic_tests/5_only_name/abis/abi5.json
+++ b/bivrost-abi-parser/src/test/resources/automatic_tests/5_only_name/abis/abi5.json
@@ -1,5 +1,5 @@
 {
-  "contract_name": "Abi5",
+  "contractName": "Abi5",
   "abi": [
     {
       "name": "function"

--- a/bivrost-abi-parser/src/test/resources/automatic_tests/6_function_input/abis/abi6.json
+++ b/bivrost-abi-parser/src/test/resources/automatic_tests/6_function_input/abis/abi6.json
@@ -1,5 +1,5 @@
 {
-  "contract_name": "Abi6",
+  "contractName": "Abi6",
   "abi": [
     {
       "constant": true,

--- a/bivrost-abi-parser/src/test/resources/automatic_tests/7_function_input_output/abis/abi7.json
+++ b/bivrost-abi-parser/src/test/resources/automatic_tests/7_function_input_output/abis/abi7.json
@@ -1,5 +1,5 @@
 {
-  "contract_name": "Abi7",
+  "contractName": "Abi7",
   "abi": [
     {
       "constant": true,

--- a/bivrost-abi-parser/src/test/resources/automatic_tests/8_unnamed_parameters/abis/abi8.json
+++ b/bivrost-abi-parser/src/test/resources/automatic_tests/8_unnamed_parameters/abis/abi8.json
@@ -1,5 +1,5 @@
 {
-  "contract_name": "Abi8",
+  "contractName": "Abi8",
   "abi": [
     {
       "constant": true,

--- a/bivrost-abi-parser/src/test/resources/automatic_tests/9_complex_arrays/abis/abi9.json
+++ b/bivrost-abi-parser/src/test/resources/automatic_tests/9_complex_arrays/abis/abi9.json
@@ -1,5 +1,5 @@
 {
-  "contract_name": "Abi9",
+  "contractName": "Abi9",
   "abi": [
     {
       "constant": true,


### PR DESCRIPTION
Changes proposed in this pull request:
- Truffle exports the contract name under `contractName` and not `contract_name`. Updated the expected key.

@gnosis/mobile-devs
