### PR TITLE
Added small fix to setup instructions in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@
 
 * Add classpath dependency:
 ```
-classpath ('com.github.gnosis:bivrost-kotlin:bivrost-gradle-plugin:<version>')
+classpath ('com.github.gnosis.bivrost-kotlin:bivrost-gradle-plugin:<version>')
 ```
 
 * Add runtime dependency:
 ```
-implementation ('com.github.gnosis:abi-kotlin:bivrost-solidity-types:<version>')
+implementation ('com.github.gnosis.abi-kotlin:bivrost-solidity-types:<version>')
 ```
 
 * Apply plugin:


### PR DESCRIPTION
README fix for setup of dependency

Changes proposed in this pull request:
- Changed the definition of of the artefacts for top level gradle file as it was not able to find them.

@gnosis/mobile-devs
