### PR TITLE
Feature/#57 replace deprecated method

### DIFF
--- a/bivrost-gradle-plugin/src/main/kotlin/pm/gnosis/plugin/BivrostPlugin.kt
+++ b/bivrost-gradle-plugin/src/main/kotlin/pm/gnosis/plugin/BivrostPlugin.kt
@@ -46,7 +46,7 @@ class BivrostPlugin : Plugin<Project> {
             val once = AtomicBoolean()
             variant.outputs.all { output ->
 
-                val processResources = output.processResources
+                val processResources = output.processResourcesProvider.get()
                 task.dependsOn(processResources)
 
                 // Though there might be multiple outputs, their R files are all the same. Thus, we only

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-all.zip


### PR DESCRIPTION
Fixed #57 .

Changes proposed in this pull request:
- Replace processResources with processResourcesProvider.get()
- Update Gradle wrapper to newest version. (At least 4.8. is necessary for processRessourcesProvider())

@gnosis/mobile-devs
